### PR TITLE
Add TabTransformer paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | [LLM Finetuning Techniques](#llm-finetuning-techniques) | - | 2024 | - | [Code](LLM_Finetunig/) |
 | [Time Series Missing Data Analysis](#time-series-missing-data-analysis) | - | 2024 | - | [Code](timeseries_missing_data/) |
 | [Tabular Deep Learning](#tabular-deep-learning) | - | 2024 | - | [Code](tabular-deep-learning-papers/) |
+| [TabTransformer](#tabtransformer) | arXiv | 2020 | [PDF](papers_pdf/tabtransformer.pdf) | [GitHub](https://github.com/lucidrains/tab-transformer-pytorch) |
 
 ## Papers by Year
 
@@ -46,3 +47,9 @@
 
 
 
+### 2021
+
+- **[TabTransformer](#tabtransformer)**
+  - Implementation focus: Transformer-based model for tabular data
+  - Key contributions: Introduces contextual embeddings for categorical features
+  - Paper: [PDF](papers_pdf/tabtransformer.pdf)


### PR DESCRIPTION
## Summary
- include TabTransformer row in the paper collection table
- document TabTransformer under a new 2021 section

## Testing
- `apt-get update`
- `apt-get install -y poppler-utils`


------
https://chatgpt.com/codex/tasks/task_e_6840878ce2e08328b4c5e249e3d1a1fb